### PR TITLE
Documentation bugs

### DIFF
--- a/ir.md
+++ b/ir.md
@@ -60,7 +60,7 @@ We use a library called PyVEX (https://github.com/angr/pyvex) that exposes VEX i
 b = angr.Project("...")
 
 # translate a basic block starting at an address
-irsb = b.block(0x4000A00)
+irsb = b.factory.block(0x4000A00)
 
 # pretty-print the basic block
 irsb.pp()


### PR DESCRIPTION
None of those irsb examples work. Looks like what you're referencing for irsb isn't actually there anymore (moved?). I was able to get one block by changing it to b.factory.block instead of b.block. However, the rest of the example (such as irsb.next, jumpkind, etc) were not in the class that was created. Super frustrating.