### PR TITLE
Don't add libs for howtowin

### DIFF
--- a/examples/mma_howtouse/howtouse.py
+++ b/examples/mma_howtouse/howtouse.py
@@ -14,7 +14,7 @@ import angr
 
 # Load the binary. Base addresses are weird when loading binaries directly, so
 # we specify it explicitly.
-p = angr.Project('howtouse.dll', load_options={'main_opts': {'custom_base_addr': 0x10000000}})
+p = angr.Project('howtouse.dll', load_options={'main_opts': {'custom_base_addr': 0x10000000}, 'auto_load_libs':False})
 
 # A "Callable" is angr's FFI-equivalent. It allows you to call binary functions
 # from Python. Here, we use it to call the `howtouse` function.


### PR DESCRIPTION
Running the script from the master repo returns the following:
```
howtouse.dll  howtouse.py
ctf@ctf-barberpole:~/workspace/angr-doc/examples/mma_howtouse$ python howtouse.py 
No handlers could be found for logger "cle.pe"
Traceback (most recent call last):
  File "howtouse.py", line 17, in <module>
    p = angr.Project('howtouse.dll', load_options={'main_opts': {'custom_base_addr': 0x10000000}})
  File "/usr/local/lib/python2.7/dist-packages/angr/project.py", line 98, in __init__
    self.loader = cle.Loader(self.filename, **load_options)
  File "/usr/local/lib/python2.7/dist-packages/cle/loader.py", line 88, in __init__
    self._load_dependencies()
  File "/usr/local/lib/python2.7/dist-packages/cle/loader.py", line 148, in _load_dependencies
    raise CLEFileNotFoundError("Could not find shared library: %s" % dep)
cle.errors.CLEFileNotFoundError: Could not find shared library: MSVCR90.dll
```

Instead of trying to load it, we can simply ignore it with setting `auto_load_libs` to `False`

```
p = angr.Project('howtouse.dll', load_options={'main_opts': {'custom_base_addr': 0x10000000},
                                               'auto_load_libs':False})
```

```
ctf@ctf-barberpole:~/workspace/angr-doc/examples/mma_howtouse$ python howtouse.py 
No handlers could be found for logger "cle.pe"
MMA{fc7d90ca001fc8712497d88d9ee7efa9e9b32ed8}
```