### PR TITLE
Generalize whitehat_crypto400.py

### DIFF
--- a/examples/whitehat_crypto400/whitehat_crypto400.py
+++ b/examples/whitehat_crypto400/whitehat_crypto400.py
@@ -57,12 +57,12 @@ print '[*] executing'
 pg.explore(find=0x4016A3).unstash(from_stash='found', to_stash='active')
 pg.explore(find=0x4016B7, avoid=[0x4017D6, 0x401699, 0x40167D]).unstash(from_stash='found', to_stash='active')
 pg.explore(find=0x4017CF, avoid=[0x4017D6, 0x401699, 0x40167D]).unstash(from_stash='found', to_stash='active')
-pg.explore(find=0x401825, avoid=[0x401811]).unstash(from_stash='found', to_stash='active')
+pg.explore(find=0x401825, avoid=[0x401811])
 
 # now, we're at stage 2. stage 2 is too complex for a SAT solver to solve, but
 # stage1 has narrowed down the keyspace enough to brute-force the rest, so
 # let's get the possible values for the passphrase and brute-force the rest.
-s = pg.active[0].state
+s = pg.found[0].state
 
 # to reduce the keyspace further, let's assume the bytes are printable
 for i in range(8):


### PR DESCRIPTION
Change for more general cases

In this example, there is only one 'active' stash remains. So, there is no problem here. But, because it is an example, I think we have to show it for more general cases. For example, in other binaries, the 'active' can be a totally different path that is searching another spaces. So, it have to bring state information from 'found' path, instead of unstashing the final 'found' path.