### PR TITLE
Fixed typos and made use of variables and imports more consistent

### DIFF
--- a/claripy.md
+++ b/claripy.md
@@ -40,49 +40,51 @@ All of the above creation code returns claripy.AST objects, on which operations 
 ASTs provide several useful operations.
 
 ```python
-b = claripy.BVV(0x41424344, 32)
+import claripy
+
+bv = claripy.BVV(0x41424344, 32)
 
 # Size - you can get the size of an AST with .size()
-assert b.size() == 32
+assert bv.size() == 32
 
 # Identity - claripy allows one to test for identity. This is a conservative
 # estimation. True means that the objects are definitely identical. False means
 # that it's hard to tell (this happens in the presense of constraint solving, for
 # example.
-assert claripy.is_identical(b, b)
+assert claripy.is_identical(bv, bv)
 
 # Reversing - .reversed is the reversed version of the BVV
-assert claripy.is_identical(b.reversed, claripy.BVV(0x44434241, 32))
-assert b.reversed.reversed is b
+assert claripy.is_identical(bv.reversed, claripy.BVV(0x44434241, 32))
+assert bv.reversed.reversed is bv
 
 # Depth - you can get the depth of the AST
-assert b.depth == 0
+assert bv.depth == 0
 x = claripy.BV('x', 32)
-assert (x+b).depth == 1
-assert ((x+b)/10).depth == 2
+assert (x+bv).depth == 1
+assert ((x+bv)/10).depth == 2
 
 # If you want to interact with the underlying object, you can call '.model'.
 # Note that, when symbolic variables are involved, this might *still* return an
 # AST
-assert type(b.model) is claripy.bv.BVV # not to be confused with claripy.BVV, claripy.bv.BVV is a python concrete bitvector representation
-assert isinstance((x+b).model, claripy.ast.Base) # no model is available for symbolic expressions
+assert type(bv.model) is claripy.bv.BVV # not to be confused with claripy.BVV, claripy.bv.BVV is a python concrete bitvector representation
+assert isinstance((x+bv).model, claripy.ast.Base) # no model is available for symbolic expressions
 ```
 
 Applying a condition (==, !=, etc) on ASTs will return an AST that represents the condition being carried out.
 For example:
 
 ```python
-r = b == x
+r = bv == x
 assert isinstance(r, claripy.ast.Bool)
 
-p = b == b
+p = bv == bv
 assert isinstance(p, claripy.ast.Bool)
 assert p.model is True
 ```
 
 You can combine these conditions in different ways.
 ```python
-q = claripy.And(claripy.Or(b == x, b * 2 == x, b * 3 == x), x == 0)
+q = claripy.And(claripy.Or(bv == x, bv * 2 == x, bv * 3 == x), x == 0)
 assert isinstance(p, claripy.ast.Bool)
 ```
 

--- a/ir.md
+++ b/ir.md
@@ -61,12 +61,17 @@ PyVEX is accessable through angr through the `Project.factory.block` interface. 
 Let's play with PyVEX:
 
 ```python
-b = angr.Project("...")
+import angr
+
+# load the program binary
+b = angr.Project("/bin/true")
+
+# translate the starting basic block
+isrb = b.factory.block(p.entry).vex
+irsb.pp()
 
 # translate a basic block starting at an address
-irsb = b.factory.block(0x4000A00).vex
-
-# pretty-print the basic block
+irsb = b.factory.block(0x401340).vex
 irsb.pp()
 
 # this is the IR Expression of the jump target of the unconditional exit at the end of the basic block

--- a/loading.md
+++ b/loading.md
@@ -6,12 +6,12 @@ CLE's main goal is to load binaries in a robust way, i.e., the same way the actu
 
 Angr, in turn, encompasses this in a *Project* class. A Project class is the entity that represents your binary, and much of your interaction with angr will go through it.
 
-To load a binary with angr (let's say "/tmp/program"), you would do the following:
+To load a binary with angr (let's say "/bin/true"), you would do the following:
 
 ```python
 import angr
 
-b = angr.Project("/tmp/program")
+b = angr.Project("/bin/true")
 ```
 
 After this, *b* is angr's representation of your binary (the "main" binary), along with any libraries that it depends on. There are several basic things that you can do here without further knowledge of the rest of the platform:
@@ -93,7 +93,7 @@ etc.
 
 Instead of using a path, you can also set the load options for all binaries on the main level.
 ```python
-p = angr.Project("...", load_options={"auto_load_libs": True})
+p = angr.Project("/bin/true", load_options={"auto_load_libs": True})
 ```
 
 ### Valid options

--- a/paths.md
+++ b/paths.md
@@ -9,7 +9,7 @@ To create a blank path, do:
 
 ```python
 # load a binary
-b = angr.Project('tests/blob/x86_64/fauxware')
+b = angr.Project('/bin/true')
 
 # load the path
 p = b.factory.path()

--- a/simuvex.md
+++ b/simuvex.md
@@ -77,8 +77,8 @@ Here is the native AMD64 code:
 And the IR of the first basic block:
 
 	>>> import angr
-	>>> p = angr.Project("/home/angr/angr/angr/tests/blob/x86_64/fauxware")
-	>>> irsb = b.block(0x400664)
+	>>> b = angr.Project("/home/angr/angr/angr/tests/blob/x86_64/fauxware")
+	>>> irsb = b.factory.block(0x400664).vex
 	>>> irsb.pp()
 	IRSB {
 	   t0:I64   t1:I64   t2:I64   t3:I64   t4:I64   t5:I64   t6:I64   t7:I64

--- a/states.md
+++ b/states.md
@@ -13,6 +13,7 @@ print "The first 5 bytes of the binary are:", s.memory.load(b.loader.min_addr(),
 
 # and the registers, of course
 print "The stack pointer starts out as:", s.regs.sp
+print "The instruction pointer starts out as:", s.regs.ip
 
 # and the temps, although these are currently empty
 print "This will throw an exception because there is no VEX temp t0, yet:", s.scratch.tmp_expr(0)
@@ -39,7 +40,8 @@ This syntax might seem a bit strange -- we get the expression from the state, an
 If you want to store content in the state's memory or registers, you'll need to create an expression out of it. You can do it like so:
 
 ```python
-# this creates a BVV (which stands for BitVector Value). A BVV is a bitvector that's used to represent data in memory, registers, and temps.
+# this creates a BVV (which stands for BitVector Value). A BVV is a bitvector that's used to represent
+# data in memory, registers, and temps. This BVV represents a 32 bit bitvector of four ascii `A` characters
 aaaa = s.BVV("AAAA")
 
 # you can create it from an integer, but then you must provide a length (in bits)
@@ -60,7 +62,7 @@ s.memory.store(0x1000, aaaa)
 s.memory.store(s.regs.rax, aaaa)
 ```
 
-For contenience, there are special accessor functions stack operations:
+For convenience, there are special accessor functions stack operations:
 
 ```python
 # push our "AAAA" onto the stack
@@ -226,6 +228,12 @@ assert s3.se.solution(m, 0)
 assert s3.se.solution(m, 5)
 assert not s3.se.solution(m, 20)
 assert not s3.se.solution(m, 30)
+
+# But the constraint does not affect the original state
+assert s.se.solution(m, 0)
+assert s.se.solution(m, 10)
+assert s.se.solution(m, 20)
+assert s.se.solution(m, 30)
 ```
 
 One cautionary piece of advice is that the comparison operators (`>`, `<`, `>=`, `<=`) are *signed* by default. That means that, in the above example, this is still the case:

--- a/toplevel.md
+++ b/toplevel.md
@@ -4,17 +4,18 @@ Top-level interfaces
 So you've loaded a project. Now what?
 
 This document explains all the attributes that are available directly from instances of `angr.Project`.
-Examples will be done with `import angr, monkeyhex; p = angr.Project('/bin/true')`.
+Examples will be done with `import angr, monkeyhex; b = angr.Project('/bin/true')`.  We use the variable
+*b* since angr.Project('...') is angr's represention of your binary.
 
 # Basic properties
 ```python
->>> p.arch
+>>> b.arch
 <Arch AMD64 (LE)>
->>> p.entry
+>>> b.entry
 0x401410
->>> p.filename
+>>> b.filename
 '/bin/true'
->>> p.loader
+>>> b.loader
 <Loaded true, maps [0x400000:0x4004000]>
 ```
 - *arch* is an instance of an `archinfo.Arch` object for whichever architecture the program is compiled.
@@ -26,12 +27,12 @@ Examples will be done with `import angr, monkeyhex; p = angr.Project('/bin/true'
 
 # Analyses and Surveyors
 ```python
->>> p.analyses
+>>> b.analyses
 <angr.analysis.Analyses object at 0x7f5220d6a890>
->>> p.surveyors
+>>> b.surveyors
 <angr.surveyor.Surveyors object at 0x7f52191b9dd0>
 
->>> filter(lambda x: '_' not in x, dir(p.analyses))
+>>> filter(lambda x: '_' not in x, dir(b.analyses))
 ['BackwardSlice',
  'BinDiff',
  'BoyScout',
@@ -45,7 +46,7 @@ Examples will be done with `import angr, monkeyhex; p = angr.Project('/bin/true'
  'VFG',
  'Veritesting',
  'XSleak']
->>> filter(lambda x: '_' not in x, dir(p.surveyors))
+>>> filter(lambda x: '_' not in x, dir(b.surveyors))
 ['Caller', 'Escaper', 'Executor', 'Explorer', 'Slicecutor', 'started']
 ```
 
@@ -62,26 +63,26 @@ Note that while surveyors are cool, an alternative to them is Path Groups (below
 
 # The factory
 
-`p.factory`, like `p.analyses` and `p.surveyors`, is a container object that has a lot of cool stuff in it.
+`b.factory`, like `b.analyses` and `b.surveyors`, is a container object that has a lot of cool stuff in it.
 It is not a factory in the java sense, it is merely a home for all the functions that produce new instances of important Angr classes and should be sitting on Project.
 
 ```python
->>> block = p.factory.block(addr=0x10000)
->>> block = p.factory.block(addr=0x20000, insn_bytes='\xc3')
->>> block = p.factory.block(addr=0x10000, num_ins=1)
+>>> block = b.factory.block(addr=0x10000)
+>>> block = b.factory.block(addr=0x20000, insn_bytes='\xc3')
+>>> block = b.factory.block(addr=0x10000, num_ins=1)
 
->>> state = p.factory.blank_state(addr=0x10000)
->>> state = p.factory.entry_state(args=['./program', angr.StringSpec(sym_length=20)])
->>> state = p.factory.full_init_state(args=['./program', angr.StringSpec(sym_length=20)])
+>>> state = b.factory.blank_state(addr=0x10000)
+>>> state = b.factory.entry_state(args=['./program', angr.StringSpec(sym_length=20)])
+>>> state = b.factory.full_init_state(args=['./program', angr.StringSpec(sym_length=20)])
 
->>> path = p.factory.path()
->>> path = p.factory.path(state)
+>>> path = b.factory.path()
+>>> path = b.factory.path(state)
 
->>> group = p.factory.path_group()
->>> group = p.factory.path_group(path)
->>> group = p.factory.path_group([path, state])
+>>> group = b.factory.path_group()
+>>> group = b.factory.path_group(path)
+>>> group = b.factory.path_group([path, state])
 
->>> strlen = p.factory.callable(0x10000)
+>>> strlen = b.factory.callable(0x10000)
 >>> strlen("hello")
 5
 ```
@@ -119,7 +120,7 @@ The `chroot` option allows you to specify an optional root to use while using th
 ```python
 >>> import simuvex
 >>> files = {'/dev/stdin': simuvex.storage.file.SimFile("/dev/stdin", "r", size=30)}
->>> s = p.factory.entry_state(fs=files, concrete_fs=True, chroot="angr-chroot/")
+>>> s = b.factory.entry_state(fs=files, concrete_fs=True, chroot="angr-chroot/")
 ```
 
 This example will create a state which constricts at most 30 symbolic bytes from being read from stdin and will cause references to files to be resolved concretely within the new root directory `angr-chroot`.
@@ -141,11 +142,11 @@ Also, you can definitely just `call(*args)` a callable to get the return value o
 >>>    state.regs.rax = 10
 >>>
 
->>> p.hook(0x10000, set_rax, length=5)
->>> p.is_hooked(0x10000)
+>>> b.hook(0x10000, set_rax, length=5)
+>>> b.is_hooked(0x10000)
 True
->>> p.unhook(0x10000)
->>> p.set_sim_procedure(p.loader.main_binary, 'strlen', simuvex.Procedures['stubs']['ReturnUnconstrained'])
+>>> b.unhook(0x10000)
+>>> b.set_sim_procedure(b.loader.main_binary, 'strlen', simuvex.Procedures['stubs']['ReturnUnconstrained'])
 ```
 
 A hook is a modification of how program execution should work.


### PR DESCRIPTION
I hope these changes are helpful.  They are things that I stumbled over when I was attempting to run through your tutorial.  In all honesty, a running example (as it seems you intend "fauxware" and "fauxware.c" to be) would be very helpful because it would make the addresses you refer to throughout the tutorial canonical.

Either way, it's a pretty cool piece of software.  Thanks!

Changes made
1) Spelling errors corrected
2) Changed ```p = angr.Project("/bin/true")``` to ```b=angr.Project("/bin/true")``` in all places for consistency
3) Added an extra few lines to example in states.md
4) Added ```import claripy``` to claripy.md
5) changed ```b = claripy.BVV``` to ```bv = claripy.BVV``` to avoid confusion with b variable associated with angr.Project
6) Made angr.Project("...") angr.Project("/bin/true") so that it's clear to users what is being analyzed
7) added the ```.vex``` call in a few places where it was missing