### PR TITLE
Fix AEG Example

### DIFF
--- a/examples/insomnihack_aeg/simple_aeg.py
+++ b/examples/insomnihack_aeg/simple_aeg.py
@@ -93,7 +93,7 @@ def main(binary):
         sc_bvv = ep.state.se.BVV(shellcode)
 
         # check satisfiability of placing shellcode into the address
-        if ep.state.satisfiable(extra_constraints=(memory == sc_bvv,)):
+        if ep.state.satisfiable(extra_constraints=(memory == sc_bvv,ep.state.regs.pc == buf_addr)):
             l.info("found buffer for shellcode, completing exploit")
             ep.state.add_constraints(memory == sc_bvv)
             l.info("pointing pc towards shellcode buffer")


### PR DESCRIPTION
Fix for issue #44 . Just makes sure that to add the constraint pc == buf_addr  when checking for satisfiability.

Otherwise the check for sat is using one constraint, but two are added to the state and it becomes unsat for certain buffers (e.g. when a NUL byte is present in the address).