### PR TITLE
Troubleshooting steps added

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -113,7 +113,6 @@ In native environment, if capstone Python files are installed in `/usr/local/lib
 
 Moving `libcapstone.so` to the same directory as that of Python files will fix the problem.
 
-
 ## Claripy and z3
 Z3 is a bit weird to compile. Sometimes it just completely fails to build for
 no reason, saying that it can't create some object file because some file or

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -87,7 +87,7 @@ Synchronization of files in and out of docker is left as an exercise to the user
 
 # Troubleshooting
 
-## libgomp.so.1: version `GOMP_4.0' not found
+## libgomp.so.1: version GOMP_4.0 not found
 This error represents an incompatibility between the pre-compiled version of `angr-only-z3-custom` and the installed version of `libgomp`. A Z3 recompile is required. You can do this by executing:
 
 ```bash
@@ -103,6 +103,16 @@ Sometimes capstone isn't installed correctly for use by angr. There's a good cha
 ```bash
 pip install -I --no-use-wheel capstone
 ```
+
+## ImportError due to failure in loading capstone while importing angr
+There's a known [issue](https://github.com/aquynh/capstone/issues/445) in installing capstone_3.0.4 using pip in virtualenv/virtualenvwrapper environment. Several users have further reported to be affected by the same bug in native Python installation, too. (See the discussion in Github bug report).
+
+In virtual environment, if capstone Python files are installed in `/home/<username>/.virtualenvs/<virtualenv>/lib/python2.7/site-packages/capstone/*.py(c)`, capstone library file will be found in `/home/<username>/.virtualenvs/<virtualenv>/lib/python2.7/site-packages/home/<username>/.virtualenvs/<virtualenv>/lib/python2.7/site-packages/capstone/libcapstone.so`
+
+In native environment, if capstone Python files are installed in `/usr/local/lib/python2.7/dist-packages/capstone/*.py(c)`, capstone library file will be found in `/usr/local/lib/python2.7/dist-packages/usr/lib/python2.7/dist-packages/capstone/libcapstone.so`
+
+Moving `libcapstone.so` to the same directory as that of Python files will fix the problem.
+
 
 ## Claripy and z3
 Z3 is a bit weird to compile. Sometimes it just completely fails to build for


### PR DESCRIPTION
Seems that the third issue in troubleshooting (`Can't import angr because of capstone`) is same/similar to the added one, except that now I have added a link to the precise bug and its fix. Please review and decide whether the third point is still relevant.