### PR TITLE
Fixed tiny typo

### DIFF
--- a/docs/symbolic.md
+++ b/docs/symbolic.md
@@ -2,7 +2,7 @@ Symbolic Execution
 ==================
 
 Symbolic execution allows at a time T to determine for a branch all conditions
-necessary to take the branch or not. Every varaible is represented as a symbolic
+necessary to take the branch or not. Every variable is represented as a symbolic
 value, and each branch as a constraint. Thus, symbolic execution allows us to
 see which conditions allows the program to go from a point A to a point B, by
 resolving the constraints.


### PR DESCRIPTION
Fixed a simple two-letter typo: varaible -> variable