### PR TITLE
Edits to Windows build/install process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 api-doc/build
 *.swp
 *.ipynb*
+windows-install/*.zip
+windows-install/*-master
+windows-install/*-win32
+windows-install/*.msi

--- a/windows-install/copy_unicorn_files.py
+++ b/windows-install/copy_unicorn_files.py
@@ -1,0 +1,15 @@
+import pkg_resources
+import shutil
+import sys
+import os
+
+if len(sys.argv) != 2:
+    print "usage: {} [unicorn-win-core-root]".format(sys.argv[0])
+    sys.exit()
+
+dest = pkg_resources.resource_filename('unicorn', 'include')
+if os.path.exists(dest):
+    shutil.rmtree(dest)
+shutil.copytree("{}{}{}".format(sys.argv[1], os.sep, 'include'), dest)
+dest = pkg_resources.resource_filename('unicorn', 'lib')
+shutil.copy("{}{}{}".format(sys.argv[1], os.sep, 'unicorn.lib'), dest)

--- a/windows-install/install_angr.bat
+++ b/windows-install/install_angr.bat
@@ -2,12 +2,18 @@
 
 powershell -Command "wget https://github.com/angr/archinfo/archive/master.zip -OutFile archinfo-master.zip"
 powershell -Command "wget https://github.com/angr/pyvex/archive/master.zip -OutFile pyvex-master.zip"
+powershell -Command "wget https://github.com/angr/cle/archive/master.zip -OutFile cle-master.zip"
+powershell -Command "wget https://github.com/angr/simuvex/archive/master.zip -OutFile simuvex-master.zip"
 powershell -Command "wget https://github.com/angr/angr/archive/master.zip -OutFile angr-master.zip"
-powershell -Command "Expand-Archive archinfo-master.zip ."
-powershell -Command "Expand-Archive pyvex-master.zip ."
-powershell -Command "Expand-Archive angr-master.zip ."
-
-pip install capstone-windows
+powershell -Command "wget https://github.com/unicorn-engine/unicorn/releases/download/1.0/unicorn-1.0.0-python-win32.msi -OutFile unicorn-python.msi"
+powershell -Command "wget https://github.com/unicorn-engine/unicorn/releases/download/1.0/unicorn-1.0-win32.zip -OutFile unicorn-core.zip"
+powershell -Command "wget https://github.com/aquynh/capstone/releases/download/3.0.5-rc2/capstone-3.0.5-rc2-python-win32.msi -OutFile capstone-python.msi"
+powershell -Command "Expand-Archive -Force archinfo-master.zip ."
+powershell -Command "Expand-Archive -Force pyvex-master.zip ."
+powershell -Command "Expand-Archive -Force cle-master.zip ."
+powershell -Command "Expand-Archive -Force simuvex-master.zip ."
+powershell -Command "Expand-Archive -Force angr-master.zip ."
+powershell -Command "Expand-Archive -Force unicorn-core.zip ."
 
 cd archinfo-master
 mv requirements.txt requirements.txt.bak
@@ -17,11 +23,28 @@ python setup.py install
 cd ..\pyvex-master
 mv requirements.txt requirements.txt.bak
 powershell -Command "wget https://raw.githubusercontent.com/Spirotot/angr_windows_install/master/requirements/pyvex_requirements.txt -OutFile requirements.txt"
-python setup.py install
+pip install -r requirements.txt
 python setup.py install
 
-cd ..\angr-master
+cd ..
+unicorn-python.msi
+if errorlevel 1 (
+    echo Warning: Unicorn installer failed!
+REM    exit /b %errorlevel%
+)
+python copy_unicorn_files.py unicorn-1.0-win32
+
+capstone-python.msi
+if errorlevel 1 (
+    echo Warning: Capstone installer failed!
+REM    exit /b %errorlevel%
+)
+
+pip install .\simuvex-master .\cle-master
+
+cd angr-master
 mv requirements.txt requirements.txt.bak
 powershell -Command "wget https://raw.githubusercontent.com/Spirotot/angr_windows_install/master/requirements/angr_requirements.txt -OutFile requirements.txt"
 pip install -r requirements.txt
-python setup.py install
+cd ..
+pip install .\angr-master


### PR DESCRIPTION
Hi `angr`y people,

I've been working on angr Windows support for some time now, with the aim of developing angr plugins for IDA running on Windows. As such, I've done a bit of work to robustify the `install_angr.bat` build script that someone else contributed earlier.

It's at the point now where I *think* you should be able to run the batch file from a VS2015 prompt and things will build and install with no errors, provided the requirements listed in `README.md` are met. I've only ever tested this from a Windows path with no spaces in it too - not sure but I suspect that paths with spaces in it could break the build. (Also worth noting that I'm using 32-bit native Python.)

I tried for *ages* to build Capstone and Unicorn locally using the same build chain, but it just wasn't going to happen without throwing further tools (e.g. MinGW) and confusion into the mix. As such, I'm just pulling down and installing binaries direct from the relevant websites. The jankiest part of this is that you get a couple of dialogs during the install process that you need to click through. I've also had success installing these into a virtualenv (in fact, I've only ever tested it using a virtualenv), by specifying install options like so:

![image](https://cloud.githubusercontent.com/assets/7539194/23643359/2e6df00e-0351-11e7-9581-a58f0c41bd41.png)

An annoying feature of this approach is that the Capstone/Unicorn installers mark themselves as "installed" in Windows after they run, so if you run the script a second time you'll get a "repair/remove" dialog instead of another "install" one.

It's possible that I've forgotten to list a dependency somewhere along the line, but I think overall this script should be a step towards a more robust build process for Windows. Would appreciate any comments/questions/criticisms/suggestions or anyone who can test it out in a fresh environment. 

Cheers,
Ben