### PR TITLE
correct solution for android_arm_license_validation

### DIFF
--- a/examples/android_arm_license_validation/solve.py
+++ b/examples/android_arm_license_validation/solve.py
@@ -33,9 +33,9 @@ def main():
     sm.explore(find=0x401840, avoid=0x401854)
     found = sm.found[0]
 
-    # Get the solution string from *(R11 - 0x24).
+    # Get the solution string from *(R11 - 0x20).
 
-    addr = found.memory.load(found.regs.r11 - 0x24, endness='Iend_LE')
+    addr = found.memory.load(found.regs.r11 - 0x20, endness='Iend_LE')
     concrete_addr = found.solver.eval(addr)
     solution = found.solver.eval(found.memory.load(concrete_addr,10), cast_to=str)
 
@@ -43,7 +43,7 @@ def main():
 
 def test():
     print "TEST MODE"
-#   assert main() == 'JQAE6ACMABNAAIIA'
+#   assert main() == 'ABGAATYAJQAFUABB'
     print main()
 
 if __name__ == '__main__':

--- a/examples/android_arm_license_validation/solve.py
+++ b/examples/android_arm_license_validation/solve.py
@@ -37,14 +37,22 @@ def main():
 
     addr = found.memory.load(found.regs.r11 - 0x20, endness='Iend_LE')
     concrete_addr = found.solver.eval(addr)
-    solution = found.solver.eval(found.memory.load(concrete_addr,10), cast_to=str)
+    user_input = found.memory.load(concrete_addr,10)
+    solution = found.solver.eval(user_input, cast_to=str)
 
-    return base64.b32encode(solution)
+    print base64.b32encode(solution)
+    return user_input, found
 
 def test():
-    print "TEST MODE"
-#   assert main() == 'ABGAATYAJQAFUABB'
-    print main()
+    user_input, found = main()
+    found.solver.add(user_input.get_byte(0) == ord('L'))
+    found.solver.add(user_input.get_byte(2) == ord('O'))
+    found.solver.add(user_input.get_byte(4) == ord('L'))
+    found.solver.add(user_input.get_byte(6) == ord('Z'))
+    found.solver.add(user_input.get_byte(8) == ord('!'))
+    solution = found.solver.eval(user_input, cast_to=str)
+    assert found.solver.satisfiable() == True
+    assert base64.b32encode(solution) == 'JQAE6ACMABNAAIIA'
 
 if __name__ == '__main__':
-    print main()
+    main()

--- a/examples/android_arm_license_validation/solve.py
+++ b/examples/android_arm_license_validation/solve.py
@@ -25,6 +25,11 @@ def main():
 
     state = b.factory.blank_state(addr=0x401760)
 
+    concrete_addr = 0xffe00000
+    code = claripy.BVS('code', 10*8)
+    state.memory.store(concrete_addr, code, endness='Iend_BE')
+    state.regs.r0 = concrete_addr
+
     sm = b.factory.simulation_manager(state)
 
     # 0x401840 = Product activation passed
@@ -35,13 +40,10 @@ def main():
 
     # Get the solution string from *(R11 - 0x20).
 
-    addr = found.memory.load(found.regs.r11 - 0x20, endness='Iend_LE')
-    concrete_addr = found.solver.eval(addr)
-    user_input = found.memory.load(concrete_addr,10)
-    solution = found.solver.eval(user_input, cast_to=str)
+    solution = found.solver.eval(code, cast_to=str)
 
     print base64.b32encode(solution)
-    return user_input, found
+    return code, found
 
 def test():
     user_input, found = main()


### PR DESCRIPTION
~~~
.text:00001760
.text:00001760                 STMFD   SP!, {R4,R11,LR}
.text:00001764                 ADD     R11, SP, #8
.text:00001768                 SUB     SP, SP, #0x1C
.text:0000176C                 STR     R0, [R11,#var_20]
.text:00001770                 LDR     R3, [R11,#var_20]
.text:00001774                 STR     R3, [R11,#var_10]
.text:00001778                 MOV     R3, #0
.text:0000177C                 STR     R3, [R11,#var_14]
~~~
According to the result of disassembler, user input is located at `state.regs.fp - 0x20`. Not sure why the original solution uses `state.regs.fp - 0x24`. 
After this change, the `solve.py` gives consistent results.