### PR TITLE
Updated fauxware example to use SimulationManager.run

### DIFF
--- a/examples/fauxware/solve.py
+++ b/examples/fauxware/solve.py
@@ -45,7 +45,7 @@ def basic_symbolic_execution():
     # Now, we begin execution. This will symbolically execute the program until
     # we reach a branch statement for which both branches are satisfiable.
 
-    sm.step(until=lambda lpg: len(lpg.active) > 1)
+    sm.run(until=lambda lpg: len(lpg.active) > 1)
 
     # If you look at the C code, you see that the first "if" statement that the
     # program can come across is comparing the result of the strcmp with the


### PR DESCRIPTION
Removed use of SimulationManager.step and replaced with SimulationManager.run.
This allows the output of solve.py to be piped into fauxware like the docs claim.

Using the SimulationManager step function generates a Deprecation warning to standard out which prevents piping the output of solve.py from working with the fauxware binary. 

Using the Deprecation Warning as a guide, the run function appears to work as well and does not generate any deprecation warnings.