### PR TITLE
Update simulation.md, more information about `mem_read` breakpoint

### DIFF
--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -148,3 +148,14 @@ Cool stuff! In fact, we can even specify a function as a condition:
 
 That is some cool stuff!
 
+
+
+### Caution about `mem_read` breakpoint
+
+The `mem_read` breakpoint gets triggered anytime there are memory reads by either the executing program or the binary analysis. If you are using breakpoint on `mem_read` and also using `state.mem` to load data from memory addresses, then know that the breakpoint will be fired as you are technically reading memory.  
+
+So if you want to load data from memory and not trigger any `mem_read` breakpoint you have had set up, then use `state.memory.load` with the keyword arguments `disable_actions=True` and `inspect=False`. 
+
+This is also true for `state.find` and you can use the same keyword arguments to prevent `mem_read` breakpoints from firing.
+
+


### PR DESCRIPTION
A little info on how to read memory for analysis and also not fire `mem_read` breakpoint. 