### PR TITLE
Add the minidump to the CLE docs

### DIFF
--- a/api-doc/source/cle.rst
+++ b/api-doc/source/cle.rst
@@ -36,6 +36,7 @@ Backends
 .. automodule:: cle.backends.macho.section
 .. automodule:: cle.backends.macho.segment
 .. automodule:: cle.backends.macho.binding
+.. automodule:: cle.backends.minidump
 .. automodule:: cle.backends.cgc
 .. automodule:: cle.backends.cgc.cgc
 .. automodule:: cle.backends.cgc.backedcgc


### PR DESCRIPTION
This PR adds the new minidump backend to the CLE docs. This is related to angr/cle#209.