### PR TITLE
Remove doc for removed code

### DIFF
--- a/api-doc/source/angr.rst
+++ b/api-doc/source/angr.rst
@@ -276,7 +276,6 @@ Analysis
 .. automodule:: angr.analyses.reaching_definitions.engine_vex
 .. automodule:: angr.analyses.reaching_definitions.live_definitions
 .. automodule:: angr.analyses.reaching_definitions.reaching_definitions
-.. automodule:: angr.analyses.reaching_definitions.def_use
 .. automodule:: angr.analyses.reaching_definitions
 .. automodule:: angr.analyses.reaching_definitions.dataset
 .. automodule:: angr.analyses.reaching_definitions.engine_ail


### PR DESCRIPTION
`DefUseAnalysis` has been merged into the RDA in angr/angr#1848 .