### PR TITLE
cast_to only support bytes and int

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -49,7 +49,7 @@ simgr.explore(find=find_addr, avoid=avoid_addr)
 
 ```python
 found = simgr.found[0] # A state that reached the find condition from explore
-found.solver.eval(sym_arg, cast_to=str) # Return a concrete string value for the sym arg to reach this state
+found.solver.eval(sym_arg, cast_to=bytes) # Return a concrete string value for the sym arg to reach this state
 ```
 
 Symbolically execute until lambda expression is `True`


### PR DESCRIPTION
reference : https://docs.angr.io/core-concepts/solver
```
cast_to can be passed a data type to cast the result to. Currently, this can only be int and bytes, which will cause the method to return the corresponding representation of the underlying data.
```