### PR TITLE
Update solve.py of java_androidnative1

### DIFF
--- a/examples/java_androidnative1/solve.py
+++ b/examples/java_androidnative1/solve.py
@@ -34,7 +34,7 @@ def test_androidnative1():
                     'entry_point': 'com.angr.nativetest1.MainActivity.onCreate',
                     'entry_point_params': ('android.os.Bundle', ),
                     'supported_jni_archs': ['x86']}
-    project = angr.Project(apk_location, main_opts=loading_opts, auto_load_libs=False)
+    project = angr.Project(apk_location, main_opts=loading_opts, auto_load_libs=True)
     project.hook(SootMethodDescriptor(class_name="java.lang.String", name="valueOf", params=('int',)).address(), Dummy_String_valueOf())
 
     blank_state = project.factory.blank_state()


### PR DESCRIPTION
If `auto_load_lib=False`,my wsl2 won't load native-lib.so .And `self.project.loader.initial_load_objects` in` javavm.py will be` **[<Apk Object androidnative1.apk, maps [0x0:0x1]>]**.
![image](https://user-images.githubusercontent.com/55612496/168034268-2a2a1705-a6c5-4469-af73-c80aeffc3efb.png)
After I changed `auto_load_lib` to True. `native-lib.so` was loaded correctly.`self.project.loader.initial_load_objects` in `javavm.py will be` **[<Apk Object androidnative1.apk, maps [0x0:0x1]>, <ELF Object libnative-lib.so, maps [0x100000:0x13338b]>, <ExternObject Object cle##externs, maps [0x200000:0x2000e8]>]**.
For more information you can take a look at loader.py:694
`while self._auto_load_libs and dependencies:`